### PR TITLE
Fix title and footnote wrapping when using flipped coords (#223)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,25 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**Code to reproduce**
+Please supply a reproducible example -- the minimum amount of code which recreates the problem you experienced.
+
+Please remove any unnecessary packages or code that are not related to the problem you are experiencing.
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/R/save_single.R
+++ b/R/save_single.R
@@ -141,9 +141,16 @@ save_single <- function(
   # update the width after this check
   width <- tot_panel_width + known_wd
 
-  plot <- update_labs(plot, tot_panel_width)
+  # If the chart has had the coords flipped, then allow the labels (titles, footnotes etc.) to be the width of the panel + left axis
+  if (isTRUE("CoordFlip" %in% class(ggplot_build(plot)$layout$coord))){
+    plot <- update_labs(plot, tot_panel_width + 0.85 * left_axis_width)
+
+  } else {
+    plot <- update_labs(plot, tot_panel_width)
+  }
 
   if(!is_spatial_chart){
+
     # update the plot_labels
     plot <- update_plot_label(plot, chart_type, base_size)
 


### PR DESCRIPTION
## Describe your changes
Added a single if statement to fix the issue with weird issue with inconsistent title and footnote wrapping when using format flip.

## Do the following before requesting a review
NA as no new functions or functionality added. I've done some basic testing with y-axis labels of different widths. The current set up isn't perfect, but it never spits out a footnote that is wider than the chart and performs fairly well for shorter axis labels.

- [ ] I have written tests covering functions I have added or changed.
- [ ] I have run tests and they all pass.
- [ ] I have ensured all new functions will show up in the `_pkgdown.yml` file and run `pkgdown::check_pkgdown()`.
- [ ] I have updated `DESCRIPTION` with any new package dependencies and the new package version number.
- [ ] I have updated `NEWS.md` with a brief description of my changes.
- [ ] I have updated the package documentation with `devtools::document()`.
- [ ] I have run `devtools::build_readme()` to update `README.md`.
- [ ] I have updated the package website with `pkgdown::build_site_github_pages()`.

## Post-release

- Create a new Release on Github with a copy of the news/changes.
- Check if Github Actions successfully deployed the package.
