### PR TITLE
Improve automated test coverage

### DIFF
--- a/tests/testthat/test-check_pkg_ver.R
+++ b/tests/testthat/test-check_pkg_ver.R
@@ -1,6 +1,12 @@
 test_that("Interactive prompt works", {
-  skip("This test only works interactively.")
+  testthat::local_mocked_bindings(
+    gh = function(...) list(list(tag_name = "v0.9.0")),
+    .env = asNamespace("gh")
+  )
+  testthat::local_mocked_bindings(
+    readline = function(...) "N",
+    .env = baseenv()
+  )
 
-  check_pkg_ver(test = TRUE)
-
+  expect_no_error(check_pkg_ver(test = TRUE))
 })

--- a/tests/testthat/test-check_pkg_ver.R
+++ b/tests/testthat/test-check_pkg_ver.R
@@ -1,26 +1,44 @@
-test_that("Interactive prompt works", {
+test_that("check_pkg_ver() is silent when package is up-to-date", {
   skip_if_not_installed("gh")
 
-  ns <- asNamespace("gh")
-  orig_gh <- get("gh", envir = ns)
-  unlockBinding("gh", ns)
-  assign("gh", function(...) list(list(tag_name = "v0.9.0")), ns)
-  lockBinding("gh", ns)
-  on.exit({
-    unlockBinding("gh", ns)
-    assign("gh", orig_gh, ns)
-    lockBinding("gh", ns)
-  }, add = TRUE)
+  local_mocked_bindings(
+    gh = function(...) list(list(tag_name = "v1.2.3")),
+    .env = asNamespace("gh")
+  )
+  local_mocked_bindings(
+    packageVersion = function(...) package_version("1.2.3"),
+    .env = asNamespace("theme61")
+  )
 
-  orig_readline <- get("readline", envir = baseenv())
-  unlockBinding("readline", baseenv())
-  assign("readline", function(...) "N", baseenv())
-  lockBinding("readline", baseenv())
-  on.exit({
-    unlockBinding("readline", baseenv())
-    assign("readline", orig_readline, baseenv())
-    lockBinding("readline", baseenv())
-  }, add = TRUE)
+  expect_silent(theme61:::check_pkg_ver())
+})
 
-  expect_no_error(check_pkg_ver(test = TRUE))
+test_that("check_pkg_ver() emits a startup message and proceeds when offline", {
+  skip_if_not_installed("gh")
+
+  local_mocked_bindings(
+    gh = function(...) stop("network down"),
+    .env = asNamespace("gh")
+  )
+
+  expect_message(
+    theme61:::check_pkg_ver(),
+    "could not check if your version of theme61 is up-to-date",
+    fixed = FALSE
+  )
+})
+
+test_that("check_pkg_ver() prompts when out-of-date (test mode) and exits on N", {
+  skip_if_not_installed("gh")
+
+  local_mocked_bindings(
+    gh = function(...) list(list(tag_name = "v999.999.999")),
+    .env = asNamespace("gh")
+  )
+  local_mocked_bindings(
+    readline = function(...) "N",
+    .env = asNamespace("theme61")
+  )
+
+  expect_message(theme61:::check_pkg_ver(test = TRUE), "out-of-date")
 })

--- a/tests/testthat/test-check_pkg_ver.R
+++ b/tests/testthat/test-check_pkg_ver.R
@@ -12,10 +12,15 @@ test_that("Interactive prompt works", {
     lockBinding("gh", ns)
   }, add = TRUE)
 
-  testthat::local_mocked_bindings(
-    readline = function(...) "N",
-    .env = baseenv()
-  )
+  orig_readline <- get("readline", envir = baseenv())
+  unlockBinding("readline", baseenv())
+  assign("readline", function(...) "N", baseenv())
+  lockBinding("readline", baseenv())
+  on.exit({
+    unlockBinding("readline", baseenv())
+    assign("readline", orig_readline, baseenv())
+    lockBinding("readline", baseenv())
+  }, add = TRUE)
 
   expect_no_error(check_pkg_ver(test = TRUE))
 })

--- a/tests/testthat/test-check_pkg_ver.R
+++ b/tests/testthat/test-check_pkg_ver.R
@@ -1,8 +1,17 @@
 test_that("Interactive prompt works", {
-  testthat::local_mocked_bindings(
-    gh = function(...) list(list(tag_name = "v0.9.0")),
-    .env = asNamespace("gh")
-  )
+  skip_if_not_installed("gh")
+
+  ns <- asNamespace("gh")
+  orig_gh <- get("gh", envir = ns)
+  unlockBinding("gh", ns)
+  assign("gh", function(...) list(list(tag_name = "v0.9.0")), ns)
+  lockBinding("gh", ns)
+  on.exit({
+    unlockBinding("gh", ns)
+    assign("gh", orig_gh, ns)
+    lockBinding("gh", ns)
+  }, add = TRUE)
+
   testthat::local_mocked_bindings(
     readline = function(...) "N",
     .env = baseenv()

--- a/tests/testthat/test-colours.R
+++ b/tests/testthat/test-colours.R
@@ -1,54 +1,15 @@
-test_that("Check colour aesthetics", {
-  skip("For interactive use only")
+test_that("palette_e61 returns palettes of the expected size", {
+  expect_equal(palette_e61(1), e61_tealdark1)
+  expect_length(palette_e61(4), 4)
+  expect_length(palette_e61(12), 12)
+})
 
-  # generate new palettes with gen_palette()
+test_that("palette_e61 reverse option returns reversed palette", {
+  pal <- palette_e61(5)
+  expect_equal(palette_e61(5, reverse = TRUE), rev(pal))
+})
 
-  set.seed(42)
-
-  # Column graph with 4 colours
-  d1 <- data.table::data.table(
-    x = 1:4,
-    y = seq(5, 25, length.out = 4)
-  )
-
-  p <- ggplot(d1, aes(x, y, fill = factor(x))) +
-    geom_col()
-
-  save_e61(tempfile(fileext = ".svg"), p)
-
-  # Column graph with as many colours as you want
-  make_graph <- function(n) {
-    d1 <- data.table::data.table(
-      x = 1:n,
-      y = seq(5, 25, length.out = n)
-    )
-
-    p <- ggplot(d1, aes(x, y, fill = factor(x))) +
-      geom_col()
-
-    save_e61(tempfile(fileext = ".svg"), p)
-  }
-
-  # Run through all the colours
-  for (i in 1:12) {
-    make_graph(i)
-    Sys.sleep(1)
-  }
-
-  # Line graph with 4 colours
-  d2 <- data.table::data.table(x = 1:10)
-
-  d2[, `:=`(y1 = 0.25*x + 10 + rnorm(10),
-            y2 = 0.5*x + 8 + rnorm(10),
-            y3 = x + 5 + rnorm(10),
-            y4 = 1.5*x + rnorm(10)
-            )]
-  d2 <- data.table::melt(d2, id.vars = "x")
-
-  p <- ggplot(d2, aes(x, y = value, colour = variable)) +
-    geom_line() +
-    scale_colour_manual(values = c(e61_skylight, e61_tealdark, e61_maroonlight, e61_orangedark))
-
-  save_e61(tempfile(fileext = ".svg"), p)
-
+test_that("palette_e61 validates palette size", {
+  expect_error(palette_e61(0))
+  expect_error(palette_e61(13))
 })

--- a/tests/testthat/test-labs_e61.R
+++ b/tests/testthat/test-labs_e61.R
@@ -46,6 +46,18 @@ test_that("Other labels (x, y, fill) are passed through correctly", {
   )
 })
 
+test_that("y_top moves y-axis title into the subtitle", {
+  lab <- labs_e61(title = "Test", subtitle = "Sub", y = "Y title", y_top = TRUE)
+
+  expect_null(lab$y)
+  expect_true(grepl("Y title", lab$subtitle, fixed = TRUE))
+})
+
+test_that("Caption is NULL when no footnotes or sources are provided", {
+  lab <- labs_e61(title = "Test", subtitle = "Sub")
+  expect_null(lab$caption)
+})
+
 test_that("Footnote and source text wrapping works sensibly", {
   lab <- labs_e61(
     title = "Test",

--- a/tests/testthat/test-plot_label.R
+++ b/tests/testthat/test-plot_label.R
@@ -290,6 +290,23 @@ test_that("Labels work on facet_wrap", {
                rep(c("1", "2"), each = 2))
 })
 
+test_that("Facet panel names must match facet variables", {
+  data <- data.frame(
+    x = rep(c(1, 2), 2),
+    y = rep(c(1, 2), 2),
+    f_var = factor(c(1, 1, 2, 2))
+  )
+
+  p <- ggplot(data, aes(x, y)) +
+    facet_wrap(~f_var) +
+    geom_point()
+
+  expect_error(
+    p + plot_label("oops", 1, 1, panel = list(bad = "1")),
+    regexp = "do not match the plot's facet variables"
+  )
+})
+
 test_that("Labels work on facet_grid", {
   df <- data.frame(
     x = 1:8,

--- a/tests/testthat/test-sec_axes_rescale.R
+++ b/tests/testthat/test-sec_axes_rescale.R
@@ -16,31 +16,26 @@ test_that("Test the function works in isolation", {
 
 
 test_that("Graphs produced with manipulated secondary axes work", {
-
-  skip("These need to be checked interactively.")
-
-  # Note: Rescaled graphs need to be run twice to save the scale/shift
-
-  # Test rescaling
-  ggplot(data.frame(x = 1, y1 = 10, y2 = 200), aes(x)) +
+  p_scale <- ggplot(data.frame(x = 1, y1 = 10, y2 = 200), aes(x)) +
     geom_point(aes(y = y1), colour = "red") +
     geom_point(aes(y = sec_rescale_inv(y2, scale = 10))) +
-    scale_y_continuous_e61(limits = c(0, 25, 5),
-                           sec_axis = sec_axis(~sec_rescale(.), name = "%"),
-                           rescale_sec = TRUE) +
+    scale_y_continuous_e61(
+      limits = c(0, 25, 5),
+      sec_axis = sec_axis(~sec_rescale(.), name = "%"),
+      rescale_sec = TRUE
+    ) +
     labs_e61(y = "%")
 
-  save_e61(tempfile(fileext = ".svg"))
-
-  # Test shift up and down
-  ggplot(data.frame(x = 1, y1 = 10, y2 = 30), aes(x)) +
+  p_shift <- ggplot(data.frame(x = 1, y1 = 10, y2 = 30), aes(x)) +
     geom_point(aes(y = y1), colour = "red") +
     geom_point(aes(y = sec_rescale_inv(y2, shift = -10))) +
-    scale_y_continuous_e61(limits = c(0, 25, 5),
-                           sec_axis = sec_axis(~sec_rescale(.), name = "%"),
-                           rescale_sec = TRUE) +
+    scale_y_continuous_e61(
+      limits = c(0, 25, 5),
+      sec_axis = sec_axis(~sec_rescale(.), name = "%"),
+      rescale_sec = TRUE
+    ) +
     labs_e61(y = "%")
 
-  save_e61(tempfile(fileext = ".svg"))
-
+  expect_no_error(ggplot_build(p_scale))
+  expect_no_error(ggplot_build(p_shift))
 })


### PR DESCRIPTION
### Motivation

- Reduce reliance on interactive behavior in tests so they can run in CI and automated environments.
- Make colour palette tests deterministic and add edge-case coverage for lab/label helpers.

### Description

- Replace the interactive `check_pkg_ver` test with mocked bindings for `gh` and `readline` so `check_pkg_ver(test = TRUE)` can be exercised non-interactively (updated `tests/testthat/test-check_pkg_ver.R`).
- Replace the long interactive colour visual tests with deterministic assertions for `palette_e61` sizes, reverse behaviour, and validation errors (recreated `tests/testthat/test-colours.R`).
- Add unit tests for `labs_e61` to verify `y_top` moves the y-axis title into the subtitle and that caption is `NULL` when no footnotes or sources are provided (updated `tests/testthat/test-labs_e61.R`).
- Add a `plot_label` test that ensures supplying `panel` names that do not match the plot's facet variables errors helpfully (updated `tests/testthat/test-plot_label.R`).
- Convert previously skipped interactive secondary-axis tests to non-interactive checks that build the ggplot objects and assert `ggplot_build` completes without error (updated `tests/testthat/test-sec_axes_rescale.R`).

### Testing

- No automated test suite was executed as part of this change; the patch updates and adds unit tests but they were not run here.
- The modified/added test files are `tests/testthat/test-check_pkg_ver.R`, `tests/testthat/test-colours.R`, `tests/testthat/test-labs_e61.R`, `tests/testthat/test-plot_label.R`, and `tests/testthat/test-sec_axes_rescale.R` and should be exercised in CI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966ebcfe0448331b0520c4499ee453d)