### PR TITLE
Reverses plot preview default so previews default to showing the Plots pane

### DIFF
--- a/R/print-e61-ggplot.R
+++ b/R/print-e61-ggplot.R
@@ -2,7 +2,7 @@
 #'
 #' - Always draws a plot in the Plots pane
 #' - Also renders a preview in the Viewer (opt-out via option)
-#' - Prefers Viewer focus by default (best-effort)
+#' - Prefers Plots focus by default
 #'
 #' @keywords internal
 #' @export

--- a/R/print-e61-ggplot.R
+++ b/R/print-e61-ggplot.R
@@ -17,20 +17,14 @@ print.e61_ggplot <- function(x, ...) {
     requireNamespace("rstudioapi", quietly = TRUE) &&
     rstudioapi::isAvailable()
 
-  # Viewer preview
+  # opt-in (default OFF): focus Viewer after printing
+  focus_viewer <- isTRUE(getOption("theme61.focus_viewer_on_print", FALSE))
+
+  # Viewer preview (render in background)
   if (in_rstudio) {
     suppressWarnings(
-      suppressMessages(
-        save_e61(
-          plot        = x,
-          preview     = TRUE,
-          format      = "svg",
-          spell_check = FALSE,
-          save_data   = FALSE,
-          print_info  = FALSE
-        )
+      suppressMessages(save_e61(plot = x, preview = TRUE, format = "svg"))
       )
-    )
   }
 
   # Plots pane render (must include theme61 defaults)
@@ -38,18 +32,10 @@ print.e61_ggplot <- function(x, ...) {
   class(x_plot) <- setdiff(class(x_plot), "e61_ggplot")
   print(x_plot)
 
-  # Prefer Viewer focus by default (best-effort)
-  if (in_rstudio) {
-    # one-shot “after plotting settles” activator
-    id <- NULL
-    id <- addTaskCallback(function(...) {
-      try(rstudioapi::executeCommand("activateViewer", quiet = TRUE), silent = TRUE)
-      removeTaskCallback(id)
-      TRUE
-    })
+  # Optional Viewer focus (off by default)
+  if (in_rstudio && focus_viewer) {
+    activate_viewer_after_plot()
   }
-
-  activate_viewer_after_plot()
 
   invisible(x)
 }


### PR DESCRIPTION
## Describe your changes

Reverses plot preview default so it defaults to showing the Plots pane. The Viewer pane still updates with a preview of what the saved graph looks like but will no longer appear by default.

## Do the following before requesting a review

### For feature branches

- [ ] I have written tests covering functions I have added or changed.
- [ ] I have run tests and they all pass.
- [ ] I have ensured all new functions show up in the `_pkgdown.yml` file.
- [ ] I have updated the package documentation with `devtools::document()`.
- [ ] I have updated `DESCRIPTION` with any new package dependencies.

