### PR TITLE
Preserve explicit y-axis breaks during autoscaling

### DIFF
--- a/R/aes-y-lims.R
+++ b/R/aes-y-lims.R
@@ -98,8 +98,18 @@ check_for_y_var <- function(plot){
 #' @noRd
 update_chart_scales <- function(plot, auto_scale, sec_axis){
 
+  y_scale <- layer_scales(plot)$y
+
   # Returns the order of the first scale function used - how do we determine this
-  y_scale_lims <- layer_scales(plot)$y$limits
+  y_scale_lims <- y_scale$limits
+
+  # Preserve user-supplied breaks if they have been explicitly provided.
+  custom_breaks <- NULL
+  if (!is.null(y_scale$breaks) &&
+      !inherits(y_scale$breaks, "waiver") &&
+      !is.function(y_scale$breaks)) {
+    custom_breaks <- y_scale$breaks
+  }
 
   # If no y-axis scale is present and y is numeric, then add a default aesthetic scale
   if(is.null(y_scale_lims) && auto_scale){
@@ -168,9 +178,17 @@ update_chart_scales <- function(plot, auto_scale, sec_axis){
   if(auto_scale){
     suppressWarnings({
       if (sec_axis) {
-        plot <- plot + scale_y_continuous_e61(limits = lims, sec_axis = dup_axis(), add_space = TRUE)
+        if (is.null(custom_breaks)) {
+          plot <- plot + scale_y_continuous_e61(limits = lims, sec_axis = dup_axis(), add_space = TRUE)
+        } else {
+          plot <- plot + scale_y_continuous_e61(limits = lims, sec_axis = dup_axis(), add_space = TRUE, breaks = custom_breaks)
+        }
       } else if (!sec_axis) {
-        plot <- plot + scale_y_continuous_e61(limits = lims, sec_axis = FALSE, add_space = TRUE)
+        if (is.null(custom_breaks)) {
+          plot <- plot + scale_y_continuous_e61(limits = lims, sec_axis = FALSE, add_space = TRUE)
+        } else {
+          plot <- plot + scale_y_continuous_e61(limits = lims, sec_axis = FALSE, add_space = TRUE, breaks = custom_breaks)
+        }
       }
     })
   }

--- a/tests/testthat/test-save_e61.R
+++ b/tests/testthat/test-save_e61.R
@@ -108,6 +108,24 @@ test_that("Y-axis customisation options", {
 
 })
 
+test_that("save_e61 autoscaling preserves custom y breaks", {
+  set.seed(1)
+  df <- data.frame(
+    x = 1:10,
+    y = rnorm(10)
+  )
+
+  p <- ggplot(df, aes(x, y)) +
+    geom_line() +
+    scale_y_continuous_e61(limits = c(-30, 30, 2))
+
+  p_scaled <- update_scales(p, auto_scale = TRUE)
+
+  breaks <- ggplot_build(p_scaled)$layout$panel_scales_y[[1]]$breaks
+
+  expect_equal(breaks, seq(-30, 30, 2))
+})
+
 test_that("Directory existence checker", {
   p <- minimal_plot
 


### PR DESCRIPTION
### Motivation
- Users who supplied custom y-axis breaks via `scale_y_continuous_e61(limits = c(min, max, step))` found those breaks overwritten by the autoscaling logic when saving plots.

### Description
- Capture the existing y scale via `y_scale <- layer_scales(plot)$y` and detect explicit breaks into a `custom_breaks` variable.
- When autoscaling inside `update_chart_scales()`, pass `breaks = custom_breaks` into `scale_y_continuous_e61(..., add_space = TRUE)` if `custom_breaks` is present, otherwise keep prior behavior.
- Added a regression test `test_that("save_e61 autoscaling preserves custom y breaks", ...)` to `tests/testthat/test-save_e61.R` that reproduces the MWE and asserts breaks remain `seq(-30, 30, 2)` after `update_scales()`.

### Testing
- Added unit test `tests/testthat/test-save_e61.R::save_e61 autoscaling preserves custom y breaks` which verifies custom breaks are preserved.
- Attempted to run `Rscript -e 'devtools::test(filter = "save_e61")'`, but the test run could not be executed in this environment because `Rscript` is not available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bec848b050833188fde01323b3d403)