### PR TITLE
Preserve custom y breaks for y-axis autoscaling and add unit test

### DIFF
--- a/R/aes-y-lims.R
+++ b/R/aes-y-lims.R
@@ -98,8 +98,18 @@ check_for_y_var <- function(plot){
 #' @noRd
 update_chart_scales <- function(plot, auto_scale, sec_axis){
 
+  y_scale <- layer_scales(plot)$y
+
   # Returns the order of the first scale function used - how do we determine this
-  y_scale_lims <- layer_scales(plot)$y$limits
+  y_scale_lims <- y_scale$limits
+
+  # Preserve user-supplied breaks if they have been explicitly provided.
+  custom_breaks <- NULL
+  if (!is.null(y_scale$breaks) &&
+      !inherits(y_scale$breaks, "waiver") &&
+      !is.function(y_scale$breaks)) {
+    custom_breaks <- y_scale$breaks
+  }
 
   # If no y-axis scale is present and y is numeric, then add a default aesthetic scale
   if(is.null(y_scale_lims) && auto_scale){
@@ -163,7 +173,28 @@ update_chart_scales <- function(plot, auto_scale, sec_axis){
   }
 
   # rescale the axis and apply requested customisations
-  lims <- if (exists("aes_lims")) aes_lims else y_scale_lims
+  # If breaks were explicitly provided and are evenly spaced, encode them as
+  # a 3-value limits vector so scale_y_continuous_e61() preserves the interval
+  # without changing its user-facing API.
+  custom_lims <- NULL
+  if (!is.null(custom_breaks) && is.numeric(custom_breaks) && length(custom_breaks) >= 2) {
+    diffs <- unique(round(diff(custom_breaks), 10))
+    diffs <- diffs[is.finite(diffs) & diffs > 0]
+
+    if (length(diffs) == 1) {
+      custom_lims <- c(min(custom_breaks, na.rm = TRUE),
+                       max(custom_breaks, na.rm = TRUE),
+                       diffs[[1]])
+    }
+  }
+
+  lims <- if (!is.null(custom_lims)) {
+    custom_lims
+  } else if (exists("aes_lims")) {
+    aes_lims
+  } else {
+    y_scale_lims
+  }
 
   if(auto_scale){
     suppressWarnings({

--- a/tests/testthat/test-save_e61.R
+++ b/tests/testthat/test-save_e61.R
@@ -108,6 +108,24 @@ test_that("Y-axis customisation options", {
 
 })
 
+test_that("save_e61 autoscaling preserves custom y breaks", {
+  set.seed(1)
+  df <- data.frame(
+    x = 1:10,
+    y = rnorm(10)
+  )
+
+  p <- ggplot(df, aes(x, y)) +
+    geom_line() +
+    scale_y_continuous_e61(limits = c(-30, 30, 2))
+
+  p_scaled <- update_scales(p, auto_scale = TRUE)
+
+  breaks <- ggplot_build(p_scaled)$layout$panel_scales_y[[1]]$breaks
+
+  expect_equal(breaks, seq(-30, 30, 2))
+})
+
 test_that("Directory existence checker", {
   p <- minimal_plot
 


### PR DESCRIPTION
### Motivation

- Ensure that user-supplied numeric y-axis breaks are preserved when autoscaling is applied so the displayed tick interval is not altered by internal limit calculations.

### Description

- Capture the plot y-scale into `y_scale` and use `y_scale$limits` rather than repeatedly calling `layer_scales(plot)$y$limits`.
- Detect and preserve user-provided breaks when they are not a `waiver` or a function by extracting `y_scale$breaks` into `custom_breaks`.
- If `custom_breaks` are numeric and evenly spaced, encode them as a 3-value limits vector `c(min, max, step)` so `scale_y_continuous_e61()` preserves the original interval; use rounding to avoid floating-point artifacts.
- Select `lims` from `custom_lims`, `aes_lims`, or `y_scale_lims` and apply them when adding `scale_y_continuous_e61()` to the plot.

### Testing

- Added `test_that("save_e61 autoscaling preserves custom y breaks", ...)` in `tests/testthat/test-save_e61.R` which creates a plot with `scale_y_continuous_e61(limits = c(-30, 30, 2))`, calls `update_scales(..., auto_scale = TRUE)`, and asserts the resulting breaks equal `seq(-30, 30, 2)`; this test was run and passed.
- Existing snapshot tests in `tests/testthat/test-save_e61.R` were executed and remained passing after the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bec848b050833188fde01323b3d403)