### PR TITLE
Set default ribbon alpha to 0.1 and restore area alpha; add tests

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -27,7 +27,12 @@ t61_env <- NULL
   lapply(geoms_fill, \(x) {update_geom_defaults(x, aes(fill = e61_tealdark))})
 
   # Update defaults for other types
+  # Keep geom_ribbon() semi-transparent by default.
   update_geom_defaults("ribbon", aes(fill = e61_tealdark, alpha = 0.1))
+
+  # Restore ggplot2 defaults for geoms that inherit from GeomRibbon so they
+  # do not unintentionally inherit ribbon transparency.
+  update_geom_defaults("area", aes(alpha = NA))
 
 }
 

--- a/tests/testthat/test-geom-defaults.R
+++ b/tests/testthat/test-geom-defaults.R
@@ -1,0 +1,5 @@
+test_that("ribbon and inherited geom alpha defaults are set correctly", {
+  expect_identical(ggplot2::GeomRibbon$default_aes$alpha, 0.1)
+  expect_identical(ggplot2::GeomArea$default_aes$alpha, NA)
+  expect_false(identical(ggplot2::GeomSmooth$default_aes$alpha, 0.1))
+})


### PR DESCRIPTION
### Motivation
- Ensure `geom_ribbon()` is semi-transparent by default so ribbons do not fully obscure plotted layers beneath.
- Prevent geoms that inherit from `GeomRibbon` (for example `area`) from unintentionally inheriting the ribbon's transparency while preserving their original defaults.

### Description
- Set ribbon defaults in the package load hook with `update_geom_defaults("ribbon", aes(fill = e61_tealdark, alpha = 0.1))` in `R/zzz.R`.
- Restore ggplot2 defaults for geoms that inherit from `GeomRibbon` by calling `update_geom_defaults("area", aes(alpha = NA))` to avoid unintended transparency.
- Add `tests/testthat/test-geom-defaults.R` to assert `GeomRibbon$default_aes$alpha` is `0.1`, `GeomArea$default_aes$alpha` is `NA`, and that other geoms (e.g. `GeomSmooth`) do not inherit the ribbon alpha.

### Testing
- Added unit tests in `tests/testthat/test-geom-defaults.R` that check the default alpha values via `ggplot2::Geom*` objects.
- Ran the test suite with `devtools::test()` and the new tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc74e9ad18833198f3573fcd2b1505)