### PR TITLE
Fix save_data in save_e61 missing .csv extension

### DIFF
--- a/R/save_e61.R
+++ b/R/save_e61.R
@@ -315,7 +315,15 @@ save_e61 <- function(filename = NULL,
   if (save_data) {
 
     for (i in seq_along(plots)) {
-      data_name <- gsub("\\.(\\w{3})$", paste0(i, ".csv"), filename)
+      # Give each plot's data file the same name as the graph. When there are
+      # multiple plots (multi-panel), append an index to keep the file names
+      # unique.
+      data_name <- if (length(plots) > 1) {
+        paste0(filename, i, ".csv")
+      } else {
+        paste0(filename, ".csv")
+      }
+
       data.table::fwrite(plots[[i]]@data, data_name)
     }
   }

--- a/tests/testthat/test-save_e61.R
+++ b/tests/testthat/test-save_e61.R
@@ -200,6 +200,18 @@ test_that("Does save_data work", {
   withr::with_tempdir({
     expect_no_error(suppressWarnings(save_e61("graph.svg", gg, save_data = TRUE)))
     expect_no_error(suppressWarnings(save_e61("graph", gg, format = "svg", save_data = TRUE)))
+
+    # The data file should include the .csv extension (#313)
+    expect_true(file.exists("graph.csv"))
+  })
+
+  # Multi-panel graphs should get one .csv per panel, each with an index and
+  # the .csv extension
+  withr::with_tempdir({
+    expect_no_error(suppressWarnings(save_e61("multi.svg", plotlist = list(gg, gg), save_data = TRUE)))
+
+    expect_true(file.exists("multi1.csv"))
+    expect_true(file.exists("multi2.csv"))
   })
 
   # This should leave the $data container empty


### PR DESCRIPTION
Superseded by a new PR from the renamed branch `claude/fix-save-data-csv-extension` (this branch, `claude/dummy-commit-pr-test-1covl9`, was named for an earlier unrelated test and is being retired). No code changes — closing in favour of the replacement PR.