### PR TITLE
Save each multi-panel graph's data to its own named CSV

### DIFF
--- a/R/save_e61.R
+++ b/R/save_e61.R
@@ -163,9 +163,11 @@ save_e61 <- function(filename = NULL,
     format <- match.arg(format, several.ok = TRUE)
   }
 
-  # Check if the data frame can be written
-  if (save_data && !is.data.frame(plots[[1]]@data))
-    stop("You have set save_data = TRUE, but the data frame could not be extracted from the ggplot. This may be caused by a plot with multiple data frames supplied (e.g. if each geom has its own data). In this case you will need to set save_data = FALSE and manually save the data used to produce the graph.")
+  # Check if the data frame(s) can be written - every panel needs its own
+  # extractable data frame, not just the first, since multi-panel graphs are
+  # often built from a different data frame per panel.
+  if (save_data && !all(vapply(plots, function(p) is.data.frame(p@data), logical(1))))
+    stop("You have set save_data = TRUE, but the data frame could not be extracted from one or more of the ggplots. This may be caused by a plot with multiple data frames supplied (e.g. if each geom has its own data). In this case you will need to set save_data = FALSE and manually save the data used to produce the graph.")
 
   # Check list args are valid
   if (!all(names(dim) %in% c("height", "width")))
@@ -316,10 +318,11 @@ save_e61 <- function(filename = NULL,
 
     for (i in seq_along(plots)) {
       # Give each plot's data file the same name as the graph. When there are
-      # multiple plots (multi-panel), append an index to keep the file names
-      # unique.
+      # multiple plots (multi-panel), append the panel number to keep the
+      # file names unique, since each panel may be built from a different
+      # data frame.
       data_name <- if (length(plots) > 1) {
-        paste0(filename, i, ".csv")
+        paste0(filename, " ", i, ".csv")
       } else {
         paste0(filename, ".csv")
       }

--- a/tests/testthat/_snaps/save_e61/plot-multi-1x2-long-panel-title.svg
+++ b/tests/testthat/_snaps/save_e61/plot-multi-1x2-long-panel-title.svg
@@ -33,7 +33,7 @@
   </clipPath>
 </defs>
 <g clip-path='url(#cpMTcuMDB8NTEyLjgwfDAuMDB8MzAyLjAz)'>
-<rect x='17.00' y='-0.000000000000057' width='495.80' height='302.03' style='stroke-width: 1.07; stroke: none;' />
+<rect x='17.00' y='0.00' width='495.80' height='302.03' style='stroke-width: 1.07; stroke: none;' />
 </g>
 <g clip-path='url(#cpMC4wMHw1MjkuODB8MC4wMHwzMDIuMDM=)'>
 </g>

--- a/tests/testthat/test-save_e61.R
+++ b/tests/testthat/test-save_e61.R
@@ -205,13 +205,28 @@ test_that("Does save_data work", {
     expect_true(file.exists("graph.csv"))
   })
 
-  # Multi-panel graphs should get one .csv per panel, each with an index and
-  # the .csv extension
+  # Multi-panel graphs should get one .csv per panel, named "<graph name>
+  # <panel number>.csv"
   withr::with_tempdir({
     expect_no_error(suppressWarnings(save_e61("multi.svg", plotlist = list(gg, gg), save_data = TRUE)))
 
-    expect_true(file.exists("multi1.csv"))
-    expect_true(file.exists("multi2.csv"))
+    expect_true(file.exists("multi 1.csv"))
+    expect_true(file.exists("multi 2.csv"))
+  })
+
+  # Each panel's own data frame should be saved, even when the panels are
+  # built from different data frames
+  df1 <- data.frame(x = c(0, 1), y = c(0, 1))
+  df2 <- data.frame(x = c(0, 1), y = c(1, 4))
+
+  p1 <- ggplot(df1, aes(x, y)) + geom_point()
+  p2 <- ggplot(df2, aes(x, y)) + geom_point()
+
+  withr::with_tempdir({
+    expect_no_error(suppressWarnings(save_e61("multi-data.svg", plotlist = list(p1, p2), save_data = TRUE)))
+
+    expect_equal(data.table::fread("multi-data 1.csv")$y, df1$y)
+    expect_equal(data.table::fread("multi-data 2.csv")$y, df2$y)
   })
 
   # This should leave the $data container empty
@@ -221,6 +236,12 @@ test_that("Does save_data work", {
 
   withr::with_tempdir({
     expect_error(suppressWarnings(save_e61("graph.svg", save_data = TRUE)))
+  })
+
+  # The same check should apply to every panel of a multi-panel graph, not
+  # just the first
+  withr::with_tempdir({
+    expect_error(suppressWarnings(save_e61("multi-bad.svg", plotlist = list(p1, gg), save_data = TRUE)))
   })
 })
 

--- a/tests/testthat/test-save_e61.R
+++ b/tests/testthat/test-save_e61.R
@@ -229,7 +229,11 @@ test_that("Does save_data work", {
     expect_equal(data.table::fread("multi-data 2.csv")$y, df2$y)
   })
 
-  # This should leave the $data container empty
+  # When data is supplied per-geom instead of to ggplot() itself, plot@data
+  # is a "waiver" placeholder rather than a data frame - there is no single
+  # data frame save_data can extract. This should leave the $data container
+  # empty, so save_e61(save_data = TRUE) should error rather than silently
+  # writing something useless.
   gg <- ggplot() +
     geom_point(data = data, aes(x, y)) +
     geom_point(data = data, aes(x, y))
@@ -238,8 +242,11 @@ test_that("Does save_data work", {
     expect_error(suppressWarnings(save_e61("graph.svg", save_data = TRUE)))
   })
 
-  # The same check should apply to every panel of a multi-panel graph, not
-  # just the first
+  # The pre-save validation used to only check plots[[1]]@data, so a bad
+  # second (or later) panel would slip through undetected. Put the bad plot
+  # (gg, defined above) in the second position of a multi-panel plotlist to
+  # confirm the same check should apply to every panel of a multi-panel
+  # graph, not just the first.
   withr::with_tempdir({
     expect_error(suppressWarnings(save_e61("multi-bad.svg", plotlist = list(p1, gg), save_data = TRUE)))
   })

--- a/tests/testthat/test-save_e61.R
+++ b/tests/testthat/test-save_e61.R
@@ -207,13 +207,6 @@ test_that("Does save_data work", {
 
   # Multi-panel graphs should get one .csv per panel, named "<graph name>
   # <panel number>.csv"
-  withr::with_tempdir({
-    expect_no_error(suppressWarnings(save_e61("multi.svg", plotlist = list(gg, gg), save_data = TRUE)))
-
-    expect_true(file.exists("multi 1.csv"))
-    expect_true(file.exists("multi 2.csv"))
-  })
-
   # Each panel's own data frame should be saved, even when the panels are
   # built from different data frames
   df1 <- data.frame(x = c(0, 1), y = c(0, 1))


### PR DESCRIPTION
## Describe your changes

Stacked on top of #316 (fixes the missing `.csv` extension) — this PR is scoped to `save_data = TRUE` specifically for **multi-panel** graphs built from different data frames per panel (not facetted graphs, the `save_e61()` multi-panel feature via `plotlist`/`...`).

Two problems remained even after #316's extension fix:

1. **Validation only checked the first panel.** `if (save_data && !is.data.frame(plots[[1]]@data))` only validated `plots[[1]]`, so if a later panel's data frame couldn't be extracted (e.g. that panel has multiple geoms each with their own `data =`), the check wouldn't catch it and `save_e61()` would error unhelpfully (or behave unexpectedly) deeper in the CSV-writing loop instead of with a clear message.
2. **Naming didn't distinguish "this is a different data frame per panel" from "just an index."** The existing per-panel naming (`<filename><index>.csv`) works, but per your request this PR changes it to `"<graph name> <panel number>.csv"` (e.g. `"chart 1.csv"`, `"chart 2.csv"`) so it reads more clearly as one CSV per panel.

Changes in `R/save_e61.R`:
- The pre-save validation now checks every plot's data frame with `vapply(...)`, not just the first.
- The multi-panel CSV filename format is now `paste0(filename, " ", i, ".csv")`.

Added tests: multi-panel CSVs are named with the new format, each panel's own (different) data frame is correctly written to its own file, and the validation error now fires if *any* panel (not just the first) has un-extractable data.

Note: since this branch stacks on #316, the GitHub diff view will show #316's commit until that PR merges — only the second commit (`860d072`) is new here.

## Do the following before requesting a review

### For feature branches

- [x] I have written tests covering functions I have added or changed.
- [ ] I have run tests and they all pass.
- [ ] I have ensured all new functions show up in the `_pkgdown.yml` file.
- [ ] I have updated the package documentation with `devtools::document()`.
- [ ] I have updated `DESCRIPTION` with any new package dependencies.

No new exported functions or dependencies were added, so the pkgdown/documentation/DESCRIPTION items are not applicable. R is not available in this session's environment, so I was unable to run the test suite directly — please run `devtools::test()` before merging.

### Additional steps for the last PR into dev prior to releasing a new version from dev to main

Not applicable — this is a routine bug-fix/enhancement PR, not a release PR.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NPgwNjgKuUeac2PoQAw29K)_