### PR TITLE
Left-align categorical y-axis text by default (closes #298)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# theme61 (development version)
+
+#### Bug fixes
+
+* Y-axis text now defaults to left-aligned when the y-axis is categorical (e.g. horizontal bar charts), instead of hugging the axis line, so it lines up with the left-aligned plot title/subtitle/y-axis title. This can still be overridden with `theme(axis.text.y = element_text(hjust = ...))` (#298).
+
 # theme61 0.7.1
 
 09 Jan 2026

--- a/R/ggplot_build-method.R
+++ b/R/ggplot_build-method.R
@@ -310,13 +310,6 @@ maybe_adjust_facet_spacing <- function(plot) {
 }
 
 # Left-align y-axis text when the y-axis is categorical (issue #298).
-#
-# The theme61 default for y-axis text is to hug the axis line (right-aligned,
-# as with a continuous scale). For categorical y-axes this creates a ragged
-# left edge that looks misaligned against the left-aligned plot
-# title/subtitle/y-axis title, especially once labels are more than a word
-# long. Left-aligning instead lines every label up with the left margin,
-# which also holds up when the categorical axis is drawn on the right.
 maybe_leftalign_discrete_y_text <- function(plot) {
 
   if (!has_discrete_y_scale(plot)) return(plot)

--- a/R/ggplot_build-method.R
+++ b/R/ggplot_build-method.R
@@ -3,6 +3,7 @@ ggplot_build.e61_ggplot <- function(plot, ...) {
 
   plot2 <- maybe_add_default_scales(plot)
   plot2 <- maybe_adjust_facet_spacing(plot2)
+  plot2 <- maybe_leftalign_discrete_y_text(plot2)
 
   # prevent recursion: drop our class before calling ggplot2 build
   class(plot2) <- setdiff(class(plot2), "e61_ggplot")
@@ -306,4 +307,31 @@ maybe_adjust_facet_spacing <- function(plot) {
   }
 
   plot
+}
+
+# Left-align y-axis text when the y-axis is categorical (issue #298).
+#
+# The theme61 default for y-axis text is to hug the axis line (right-aligned,
+# as with a continuous scale). For categorical y-axes this creates a ragged
+# left edge that looks misaligned against the left-aligned plot
+# title/subtitle/y-axis title, especially once labels are more than a word
+# long. Left-aligning instead lines every label up with the left margin,
+# which also holds up when the categorical axis is drawn on the right.
+maybe_leftalign_discrete_y_text <- function(plot) {
+
+  if (!has_discrete_y_scale(plot)) return(plot)
+
+  th <- plot@theme
+
+  # Respect any user-specified alignment for y-axis text.
+  has_hjust <- function(el) inherits(el, "element_text") && !is.null(el$hjust)
+
+  theme_args <- list()
+
+  if (!has_hjust(th$axis.text.y)) theme_args$axis.text.y <- element_text(hjust = 0)
+  if (!has_hjust(th$axis.text.y.right)) theme_args$axis.text.y.right <- element_text(hjust = 0)
+
+  if (length(theme_args) == 0) return(plot)
+
+  plot + do.call(theme, theme_args)
 }

--- a/R/ggplot_build-method.R
+++ b/R/ggplot_build-method.R
@@ -309,7 +309,7 @@ maybe_adjust_facet_spacing <- function(plot) {
   plot
 }
 
-# Left-align y-axis text when the y-axis is categorical (issue #298).
+# Left-align y-axis text when the y-axis is categorical.
 maybe_leftalign_discrete_y_text <- function(plot) {
 
   if (!has_discrete_y_scale(plot)) return(plot)

--- a/tests/testthat/_snaps/save_e61/plot-multi-1x2-long-panel-title.svg
+++ b/tests/testthat/_snaps/save_e61/plot-multi-1x2-long-panel-title.svg
@@ -33,7 +33,7 @@
   </clipPath>
 </defs>
 <g clip-path='url(#cpMTcuMDB8NTEyLjgwfDAuMDB8MzAyLjAz)'>
-<rect x='17.00' y='0.00' width='495.80' height='302.03' style='stroke-width: 1.07; stroke: none;' />
+<rect x='17.00' y='-0.000000000000057' width='495.80' height='302.03' style='stroke-width: 1.07; stroke: none;' />
 </g>
 <g clip-path='url(#cpMC4wMHw1MjkuODB8MC4wMHwzMDIuMDM=)'>
 </g>

--- a/tests/testthat/_snaps/save_e61/plot-multi-1x2-long-panel-title.svg
+++ b/tests/testthat/_snaps/save_e61/plot-multi-1x2-long-panel-title.svg
@@ -33,7 +33,7 @@
   </clipPath>
 </defs>
 <g clip-path='url(#cpMTcuMDB8NTEyLjgwfDAuMDB8MzAyLjAz)'>
-<rect x='17.00' y='-0.000000000000057' width='495.80' height='302.03' style='stroke-width: 1.07; stroke: none;' />
+<rect x='17.00' y='0.00' width='495.80' height='302.03' style='stroke-width: 1.07; stroke: none;' />
 </g>
 <g clip-path='url(#cpMC4wMHw1MjkuODB8MC4wMHwzMDIuMDM=)'>
 </g>

--- a/tests/testthat/test-ggplot2-wrappers.R
+++ b/tests/testthat/test-ggplot2-wrappers.R
@@ -265,6 +265,54 @@ test_that("user-specified panel.spacing is not overridden", {
   expect_equal(th$panel.spacing.y, user_spacing_y)
 })
 
+test_that("categorical y-axis text is left-aligned by default (#298)", {
+
+  df <- data.frame(
+    category = c("Short", "A much longer category label"),
+    value = c(1, 2)
+  )
+
+  p <- ggplot(df, aes(x = value, y = category)) +
+    geom_col()
+
+  b <- ggplot_build(p)
+  th <- b@plot@theme
+
+  expect_equal(th$axis.text.y$hjust, 0)
+  expect_equal(th$axis.text.y.right$hjust, 0)
+})
+
+test_that("continuous y-axis text alignment is untouched (#298)", {
+
+  df <- data.frame(x = 1:5, y = (1:5)^2)
+
+  p <- ggplot(df, aes(x, y)) +
+    geom_point()
+
+  b <- ggplot_build(p)
+  th <- b@plot@theme
+
+  expect_null(th$axis.text.y$hjust)
+  expect_null(th$axis.text.y.right$hjust)
+})
+
+test_that("user-specified y-axis text alignment is not overridden (#298)", {
+
+  df <- data.frame(
+    category = c("Short", "A much longer category label"),
+    value = c(1, 2)
+  )
+
+  p <- ggplot(df, aes(x = value, y = category)) +
+    geom_col() +
+    theme(axis.text.y = element_text(hjust = 1))
+
+  b <- ggplot_build(p)
+  th <- b@plot@theme
+
+  expect_equal(th$axis.text.y$hjust, 1)
+})
+
 testthat::test_that("ggplot2::facet_wrap is not auto-adjusted (facet not tagged)", {
 
   old <- options(quiet_wrap = TRUE)


### PR DESCRIPTION
## Describe your changes

Implements the solution proposed by @Anile61 in #298: when the y-axis is categorical, axis text now defaults to left-aligned instead of right-aligned (hugging the axis line). Right-aligned labels create a ragged left edge that looks misaligned against the left-aligned plot title/subtitle/y-axis title once category labels are more than a word long. This also holds up when the categorical axis is drawn on the right (`axis.text.y.right`).

The default can still be overridden with `theme(axis.text.y = element_text(hjust = ...))`.

### Implementation

- `R/ggplot_build-method.R`: added `maybe_leftalign_discrete_y_text()`, wired into `ggplot_build.e61_ggplot()` alongside the existing default-scale/facet-spacing build-time adjustments. It reuses the existing `has_discrete_y_scale()` helper to detect a categorical y-axis, then sets `axis.text.y`/`axis.text.y.right` to `hjust = 0` — but only for whichever of those the user hasn't already customized.
- `tests/testthat/test-ggplot2-wrappers.R`: added tests covering the categorical case, the continuous case (untouched), and that a user-specified `hjust` is respected.
- `NEWS.md`: added a bug-fix entry.

Closes #298.

## Do the following before requesting a review

### For feature branches

- [x] I have written tests covering functions I have added or changed.
- [x] I have run tests and they all pass. (Could not run `devtools::test()` in this sandbox — no network access to CRAN to install package dependencies. Logic was manually traced against the existing `maybe_adjust_facet_spacing` pattern; please run the suite locally before merging.)
- [ ] I have ensured all new functions show up in the `_pkgdown.yml` file. (N/A — new function is internal/`@noRd`, not exported.)
- [ ] I have updated the package documentation with `devtools::document()`. (N/A — no exported/documented functions changed.)
- [ ] I have updated `DESCRIPTION` with any new package dependencies. (N/A — no new dependencies.)


---
_Generated by [Claude Code](https://claude.ai/code/session_012F8kCsXzxvY8eYpRfkzuzv)_