### PR TITLE
Add return_plot_obj argument to save_e61() for multi-panel graphs (closes #216)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # theme61 (development version)
 
+#### New features
+
+* Added a `return_plot_obj` argument to `save_e61()` for multi-panel graphs (2 or more plots). When `TRUE`, `save_e61()` skips saving entirely and returns the composed multi-panel plot object instead of writing it to disk - e.g. to print it in the Plots pane, or use it in a Shiny app (closes #216). No `filename` is required in this mode. Not supported for single-panel graphs, since you can already just print the ggplot object directly. Note the returned object's layout (text sizes, panel spacing) is computed for a fixed target size (`dim`, or the same defaults `save_e61()` would otherwise use), so it won't reflow if you resize the device afterwards - the same way a saved image wouldn't.
+
 #### Performance
 
 * `save_e61()`/`print()` no longer re-render the same plot from scratch several times over. `update_scales()` now builds the plot once and reuses that build for its internal y-variable, secondary-axis and y-min/max checks (previously up to 3 separate builds), and `save_single()` no longer builds the plot just to check for `coord_flip()` (reads the coord class off the plot object instead) or builds it unconditionally to count facet panels (now only when facets are actually present). No change in output.

--- a/R/save_e61.R
+++ b/R/save_e61.R
@@ -70,6 +70,15 @@
 #'   cramped on the chart.
 #' @param rel_heights (multi-panel specific) A numeric vector giving the
 #'   relative proportions of each graph component (title, plots, footer).
+#' @param return_plot_obj (multi-panel specific) Logical. If TRUE, skips
+#'   saving entirely and returns the composed multi-panel plot object instead
+#'   (e.g. to print it in the Plots pane, or use it in a Shiny app). Only
+#'   supported for multi-panel graphs (2 or more plots) - for a single plot,
+#'   just print the ggplot object directly. Defaults to FALSE. Like a saved
+#'   graph, the returned object's layout (text sizes, panel spacing) is
+#'   computed for a fixed target size (`dim`, or the same defaults `save_e61`
+#'   would otherwise use) - it won't reflow if you resize the device
+#'   afterwards.
 #' @inheritParams labs_e61
 #' @inheritParams cowplot::plot_grid
 #' @return Invisibly returns the file name.
@@ -104,7 +113,8 @@ save_e61 <- function(filename = NULL,
                      nrow = NULL,
                      align = c("v", "none", "h", "hv"),
                      axis = c("none", "l", "r", "t", "b", "lr", "tb", "tblr"),
-                     rel_heights = NULL
+                     rel_heights = NULL,
+                     return_plot_obj = FALSE
                      ) {
 
   # Compile plots
@@ -117,6 +127,10 @@ save_e61 <- function(filename = NULL,
 
   # Check whether the plots are ggplot2 objects
   plots <- check_plots(plots)
+
+  if (return_plot_obj && length(plots) <= 1) {
+    stop("return_plot_obj is only supported for multi-panel graphs (2 or more plots). For a single plot, just print the ggplot object directly.")
+  }
 
   # Enforce chart type
   if(is.null(chart_type)){
@@ -135,37 +149,46 @@ save_e61 <- function(filename = NULL,
     }
   }
 
-  # Check if filename has been provided when preview mode is FALSE
-  if (!preview && is.null(filename)) stop("You must provide a file path to save the graph.")
+  # Check if filename has been provided when preview/return_plot_obj mode is FALSE
+  if (!preview && !return_plot_obj && is.null(filename)) stop("You must provide a file path to save the graph.")
 
   # Override save directory with temp file if preview mode is TRUE
-  if (preview) {
+  if (preview && !return_plot_obj) {
     cli::cli_alert_info("Preview mode is activated, file will not be saved to disk.")
     filename <- tempfile(fileext = ".svg")
   }
 
-  # Check if the save directory exists
-  dir_provided <- grepl("^(.*)\\/.*\\..{3}$", filename)
-  dir_name <- gsub("^(.*)\\/.*\\..{3}$", "\\1", filename)
+  # Check if the save directory exists (not applicable if we're just
+  # returning the plot object - nothing gets written to disk)
+  if (!return_plot_obj) {
+    dir_provided <- grepl("^(.*)\\/.*\\..{3}$", filename)
+    dir_name <- gsub("^(.*)\\/.*\\..{3}$", "\\1", filename)
 
-  if (dir_provided && !dir.exists(dir_name))
-    stop("The directory you are trying to save to does not exist.")
-
-  # Enforce file format requirements if a file extension is provided
-  if (grepl("\\..{3}$", filename) && !grepl("\\.(svg|pdf|eps|png|jpg)$", filename)) {
-    stop("You must provide a valid file extension. The following file formats are supported: svg, pdf, eps, png, jpg.")
+    if (dir_provided && !dir.exists(dir_name))
+      stop("The directory you are trying to save to does not exist.")
   }
 
-  # Determine which file formats to save
-  if (grepl("\\..{3}$", filename)) {
-    format <- gsub("^.*\\.(.{3})$", "\\1", filename)
+  # Skip file format resolution entirely if we're just returning the plot
+  # object - nothing gets written to disk, so filename/format are unused
+  # (and filename may be NULL, which the checks below can't handle).
+  if (!return_plot_obj) {
 
-    # Strip file extension from filename
-    filename <- gsub("^(.*)\\..{3}$", "\\1", filename)
-  } else if (is.null(format) && !is.null(getOption("theme61.default_save_format"))) {
-    format <- getOption("theme61.default_save_format")
-  } else {
-    format <- match.arg(format, several.ok = TRUE)
+    # Enforce file format requirements if a file extension is provided
+    if (grepl("\\..{3}$", filename) && !grepl("\\.(svg|pdf|eps|png|jpg)$", filename)) {
+      stop("You must provide a valid file extension. The following file formats are supported: svg, pdf, eps, png, jpg.")
+    }
+
+    # Determine which file formats to save
+    if (grepl("\\..{3}$", filename)) {
+      format <- gsub("^.*\\.(.{3})$", "\\1", filename)
+
+      # Strip file extension from filename
+      filename <- gsub("^(.*)\\..{3}$", "\\1", filename)
+    } else if (is.null(format) && !is.null(getOption("theme61.default_save_format"))) {
+      format <- getOption("theme61.default_save_format")
+    } else {
+      format <- match.arg(format, several.ok = TRUE)
+    }
   }
 
   # Check if the data frame(s) can be written - every panel needs its own
@@ -279,6 +302,10 @@ save_e61 <- function(filename = NULL,
       rel_heights = rel_heights,
       bg_colour = bg_colour
     )
+
+    # Short-circuit: return the composed plot object instead of saving it
+    if (return_plot_obj) return(save_input$graph)
+
   } else {
 
     temp <- plots[[1]]

--- a/man/save_e61.Rd
+++ b/man/save_e61.Rd
@@ -33,7 +33,8 @@ save_e61(
   nrow = NULL,
   align = c("v", "none", "h", "hv"),
   axis = c("none", "l", "r", "t", "b", "lr", "tb", "tblr"),
-  rel_heights = NULL
+  rel_heights = NULL,
+  return_plot_obj = FALSE
 )
 }
 \arguments{
@@ -132,6 +133,16 @@ manual control if you need it.}
 
 \item{rel_heights}{(multi-panel specific) A numeric vector giving the
 relative proportions of each graph component (title, plots, footer).}
+
+\item{return_plot_obj}{(multi-panel specific) Logical. If TRUE, skips
+saving entirely and returns the composed multi-panel plot object instead
+(e.g. to print it in the Plots pane, or use it in a Shiny app). Only
+supported for multi-panel graphs (2 or more plots) - for a single plot,
+just print the ggplot object directly. Defaults to FALSE. Like a saved
+graph, the returned object's layout (text sizes, panel spacing) is
+computed for a fixed target size (\code{dim}, or the same defaults \code{save_e61}
+would otherwise use) - it won't reflow if you resize the device
+afterwards.}
 }
 \value{
 Invisibly returns the file name.

--- a/tests/testthat/test-save_e61.R
+++ b/tests/testthat/test-save_e61.R
@@ -254,6 +254,39 @@ test_that("Does save_data work", {
   })
 })
 
+test_that("return_plot_obj returns the composed multi-panel object without saving", {
+
+  df1 <- data.frame(x = c(0, 1), y = c(0, 1))
+  df2 <- data.frame(x = c(0, 1), y = c(1, 4))
+
+  p1 <- ggplot(df1, aes(x, y)) + geom_point()
+  p2 <- ggplot(df2, aes(x, y)) + geom_point()
+
+  withr::with_tempdir({
+    obj <- save_e61(plotlist = list(p1, p2), title = "Combined", return_plot_obj = TRUE)
+
+    expect_s3_class(obj, "patchwork")
+    expect_length(list.files(), 0)
+  })
+})
+
+test_that("return_plot_obj errors for a single plot", {
+  expect_error(
+    save_e61(plotlist = list(minimal_plot), return_plot_obj = TRUE),
+    "only supported for multi-panel graphs"
+  )
+})
+
+test_that("return_plot_obj doesn't require a filename", {
+  df1 <- data.frame(x = c(0, 1), y = c(0, 1))
+  df2 <- data.frame(x = c(0, 1), y = c(1, 4))
+
+  p1 <- ggplot(df1, aes(x, y)) + geom_point()
+  p2 <- ggplot(df2, aes(x, y)) + geom_point()
+
+  expect_no_error(save_e61(plotlist = list(p1, p2), return_plot_obj = TRUE))
+})
+
 test_that("resolve_aspect_ratio respects user theme customisations", {
 
   p <- minimal_plot # already carries theme_e61()'s default aspect.ratio = 0.75


### PR DESCRIPTION
## Describe your changes

Addresses #216 ("multi-panel charts in plots pane"). The composed multi-panel figure was already being built as a plain `patchwork` object inside `save_multi()` before any file gets written - `save_e61()` just never returned it, only ever passed it to `save_graph()` to write to disk.

Adds a `return_plot_obj` argument to `save_e61()`, scoped to multi-panel graphs only:

- `save_e61(plotlist = list(p1, p2), title = ..., return_plot_obj = TRUE)` short-circuits right after `save_multi()` builds the composed object and returns it (visibly, so it auto-prints if called at the console), instead of calling `save_graph()`. Nothing gets written to disk, and no `filename` is required.
- Only valid for 2+ plots - for a single plot, `save_e61()` now errors with a clear message pointing to just printing the ggplot object directly, since there's nothing this argument would add there.
- Note: since `filename` isn't provided in a positional call once there's no file to name, use `plotlist = list(...)` (or `filename = NULL` explicitly) rather than bare `save_e61(p1, p2, ...)` - otherwise `p1` silently binds to the `filename` argument. This is true of multi-panel `save_e61()` calls generally, just more likely to be hit here since there's no natural filename to anchor position 1.
- Like a saved image, the returned object's layout (text sizes, panel spacing, aspect ratios) is computed for a fixed target size (`dim`, or the same defaults `save_e61()` already uses) - it won't reflow if the device is resized afterwards. That's inherent to how multi-panel layout is computed (needs a target size up front to size panels/rescale text), not something this change introduces or could avoid. This is a non-issue for the Shiny use case mentioned in the issue, since Shiny re-runs the render expression (and can pass the current device size via `dim`) on every resize anyway.

### Changes made

- `R/save_e61.R`: added `return_plot_obj` parameter; guarded the filename-required check, directory-exists check, and file-format resolution so they're skipped when `return_plot_obj = TRUE` (since `filename` may be `NULL`); short-circuits with `return(save_input$graph)` right after `save_multi()` builds the object.
- `man/save_e61.Rd`: documented the new argument (hand-edited to mirror the roxygen source - see note below).
- `tests/testthat/test-save_e61.R`: added tests covering the returned object's class, that nothing is written to disk, the single-panel error, and that no filename is required.
- `NEWS.md`: added an entry under "New features".

## Do the following before requesting a review

### For feature branches

- [x] I have written tests covering functions I have added or changed.
- [x] I have run tests and they all pass (`tests/testthat/test-save_e61.R`, run against a locally-built R environment with the relevant dependencies installed - pre-existing skips are for `rsvg`/`sf` not being installed there, unrelated to this change).
- [x] I have ensured all new functions show up in the `_pkgdown.yml` file. (No new exported functions - `return_plot_obj` is a new argument on the existing, already-listed `save_e61()`.)
- [ ] I have updated the package documentation with `devtools::document()`. `roxygen2` wasn't available in my environment, so `man/save_e61.Rd` was hand-edited to match the roxygen source - **please run `devtools::document()` before merging to confirm it regenerates identically.**
- [x] I have updated `DESCRIPTION` with any new package dependencies. (None needed - no new packages used.)

https://claude.ai/code/session_01QVF3jhd4VKf5Gx4aoquJ9Y

---
_Generated by [Claude Code](https://claude.ai/code/session_01QVF3jhd4VKf5Gx4aoquJ9Y)_